### PR TITLE
V1 release

### DIFF
--- a/css/design_system/elements/p.scss
+++ b/css/design_system/elements/p.scss
@@ -1,0 +1,16 @@
+/**
+ * @title Paragraph
+ * @category elements
+ * @element_type text
+ * @status draft
+ * @value s-p
+ * @description A paragraph element with built-in size, color, and font-family. To be used with a white background.
+ *
+ * @example
+ * <p class="s-p">The default paragraph text is 16px and is intended for text on a white background.</p>
+ */
+
+.s-p {
+  color: var(--s-color-gray-600);
+  font-size: var(--s-font-size-md);
+}

--- a/css/design_system/index.scss
+++ b/css/design_system/index.scss
@@ -10,5 +10,6 @@
 @import "elements/primary-button";
 @import "elements/primary-inverse-button";
 @import "elements/secondary-button";
+@import "elements/p";
 
 @import "components/nav";

--- a/css/versions/v-1.css
+++ b/css/versions/v-1.css
@@ -1,0 +1,260 @@
+/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
+/* Document ========================================================================== */
+/** 1. Correct the line height in all browsers. 2. Prevent adjustments of font size after orientation changes in iOS. */
+html { line-height: 1.15; /* 1 */ -webkit-text-size-adjust: 100%; /* 2 */ }
+
+/* Sections ========================================================================== */
+/** Remove the margin in all browsers. */
+body { margin: 0; }
+
+/** Render the `main` element consistently in IE. */
+main { display: block; }
+
+/** Correct the font size and margin on `h1` elements within `section` and `article` contexts in Chrome, Firefox, and Safari. */
+h1 { font-size: 2em; margin: 0.67em 0; }
+
+/* Grouping content ========================================================================== */
+/** 1. Add the correct box sizing in Firefox. 2. Show the overflow in Edge and IE. */
+hr { box-sizing: content-box; /* 1 */ height: 0; /* 1 */ overflow: visible; /* 2 */ }
+
+/** 1. Correct the inheritance and scaling of font size in all browsers. 2. Correct the odd `em` font sizing in all browsers. */
+pre { font-family: monospace, monospace; /* 1 */ font-size: 1em; /* 2 */ }
+
+/* Text-level semantics ========================================================================== */
+/** Remove the gray background on active links in IE 10. */
+a { background-color: transparent; }
+
+/** 1. Remove the bottom border in Chrome 57- 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari. */
+abbr[title] { border-bottom: none; /* 1 */ text-decoration: underline; /* 2 */ text-decoration: underline dotted; /* 2 */ }
+
+/** Add the correct font weight in Chrome, Edge, and Safari. */
+b, strong { font-weight: bolder; }
+
+/** 1. Correct the inheritance and scaling of font size in all browsers. 2. Correct the odd `em` font sizing in all browsers. */
+code, kbd, samp { font-family: monospace, monospace; /* 1 */ font-size: 1em; /* 2 */ }
+
+/** Add the correct font size in all browsers. */
+small { font-size: 80%; }
+
+/** Prevent `sub` and `sup` elements from affecting the line height in all browsers. */
+sub, sup { font-size: 75%; line-height: 0; position: relative; vertical-align: baseline; }
+
+sub { bottom: -0.25em; }
+
+sup { top: -0.5em; }
+
+/* Embedded content ========================================================================== */
+/** Remove the border on images inside links in IE 10. */
+img { border-style: none; }
+
+/* Forms ========================================================================== */
+/** 1. Change the font styles in all browsers. 2. Remove the margin in Firefox and Safari. */
+button, input, optgroup, select, textarea { font-family: inherit; /* 1 */ font-size: 100%; /* 1 */ line-height: 1.15; /* 1 */ margin: 0; /* 2 */ }
+
+/** Show the overflow in IE. 1. Show the overflow in Edge. */
+button, input { /* 1 */ overflow: visible; }
+
+/** Remove the inheritance of text transform in Edge, Firefox, and IE. 1. Remove the inheritance of text transform in Firefox. */
+button, select { /* 1 */ text-transform: none; }
+
+/** Correct the inability to style clickable types in iOS and Safari. */
+button, [type="button"], [type="reset"], [type="submit"] { -webkit-appearance: button; }
+
+/** Remove the inner border and padding in Firefox. */
+button::-moz-focus-inner, [type="button"]::-moz-focus-inner, [type="reset"]::-moz-focus-inner, [type="submit"]::-moz-focus-inner { border-style: none; padding: 0; }
+
+/** Restore the focus styles unset by the previous rule. */
+button:-moz-focusring, [type="button"]:-moz-focusring, [type="reset"]:-moz-focusring, [type="submit"]:-moz-focusring { outline: 1px dotted ButtonText; }
+
+/** Correct the padding in Firefox. */
+fieldset { padding: 0.35em 0.75em 0.625em; }
+
+/** 1. Correct the text wrapping in Edge and IE. 2. Correct the color inheritance from `fieldset` elements in IE. 3. Remove the padding so developers are not caught out when they zero out `fieldset` elements in all browsers. */
+legend { box-sizing: border-box; /* 1 */ color: inherit; /* 2 */ display: table; /* 1 */ max-width: 100%; /* 1 */ padding: 0; /* 3 */ white-space: normal; /* 1 */ }
+
+/** Add the correct vertical alignment in Chrome, Firefox, and Opera. */
+progress { vertical-align: baseline; }
+
+/** Remove the default vertical scrollbar in IE 10+. */
+textarea { overflow: auto; }
+
+/** 1. Add the correct box sizing in IE 10. 2. Remove the padding in IE 10. */
+[type="checkbox"], [type="radio"] { box-sizing: border-box; /* 1 */ padding: 0; /* 2 */ }
+
+/** Correct the cursor style of increment and decrement buttons in Chrome. */
+[type="number"]::-webkit-inner-spin-button, [type="number"]::-webkit-outer-spin-button { height: auto; }
+
+/** 1. Correct the odd appearance in Chrome and Safari. 2. Correct the outline style in Safari. */
+[type="search"] { -webkit-appearance: textfield; /* 1 */ outline-offset: -2px; /* 2 */ }
+
+/** Remove the inner padding in Chrome and Safari on macOS. */
+[type="search"]::-webkit-search-decoration { -webkit-appearance: none; }
+
+/** 1. Correct the inability to style clickable types in iOS and Safari. 2. Change font properties to `inherit` in Safari. */
+::-webkit-file-upload-button { -webkit-appearance: button; /* 1 */ font: inherit; /* 2 */ }
+
+/* Interactive ========================================================================== */
+/* Add the correct display in Edge, IE 10+, and Firefox. */
+details { display: block; }
+
+/* Add the correct display in all browsers. */
+summary { display: list-item; }
+
+/* Misc ========================================================================== */
+/** Add the correct display in IE 10+. */
+template { display: none; }
+
+/** Add the correct display in IE 10. */
+[hidden] { display: none; }
+
+:root { /** @title --s-font-size-xxs @category tokens @token_type font-size @value 0.625rem @description xxs Font size */ --s-font-size-xxs: 0.625rem; /** @title --s-font-size-xs @category tokens @token_type font-size @value 0.75rem @description xs Font size */ --s-font-size-xs: 0.75rem; /** @title --s-font-size-sm @category tokens @token_type font-size @value 0.875rem @description sm Font size */ --s-font-size-sm: 0.875rem; /** @title --s-font-size-md @category tokens @token_type font-size @value 1rem @description md Font size */ --s-font-size-md: 1rem; /** @title --s-font-size-lg @category tokens @token_type font-size @value 1.5rem @description lg Font size */ --s-font-size-lg: 1.5rem; /** @title --s-font-size-xl @category tokens @token_type font-size @value 2rem @description xl Font size */ --s-font-size-xl: 2rem; /** @title --s-font-size-xxl @category tokens @token_type font-size @value 3rem @description xxl Font size */ --s-font-size-xxl: 3rem; /** @title --s-font-weight-ultra-light @category tokens @token_type font-weight @value 200 @description ultra-light Font weight */ --s-font-weight-ultra-light: 200; /** @title --s-font-weight-light @category tokens @token_type font-weight @value 300 @description light Font weight */ --s-font-weight-light: 300; /** @title --s-font-weight-normal @category tokens @token_type font-weight @value 400 @description normal Font weight */ --s-font-weight-normal: 400; /** @title --s-font-weight-bold @category tokens @token_type font-weight @value 700 @description bold Font weight */ --s-font-weight-bold: 700; /** @title --s-font-weight-heavy @category tokens @token_type font-weight @value 900 @description heavy Font weight */ --s-font-weight-heavy: 900; /** @title --s-font-family-default @category tokens @token_type font-family @value Helvetica Neue Default Font Family */ --s-font-family-default: "Helvetica Neue", Helvetica, sans-serif; /** @title --s-font-family-alternate @category tokens @token_type font-family @value Roboto Slab Alternate Font Family */ --s-font-family-alternate: "Roboto Slab", sans-serif; /** @title --s-font-family-mono @category tokens @token_type font-family @value Roboto Mono Monospace Font Family */ --s-font-family-mono: "Roboto Mono", monospace; }
+
+/* NOTE: we use the literal font-weight values in all @font-face declarations b/c using var() breaks the dynamic font loading */
+@font-face { font-family: 'Helvetica Neue'; src: url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W25_Ultra_Light.woff2") format("woff2"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W25_Ultra_Light.woff") format("woff"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W25_Ultra_Light.ttf") format("truetype"); font-style: normal; font-weight: 200; }
+
+@font-face { font-family: 'Helvetica Neue'; src: url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W25_Ultra_Light_Italic.woff2") format("woff2"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W25_Ultra_Light_Italic.woff") format("woff"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W25_Ultra_Light_Italic.ttf") format("truetype"); font-style: italic; font-weight: 200; }
+
+@font-face { font-family: 'Helvetica Neue'; src: url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W35_Thin.woff2") format("woff2"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W35_Thin.woff") format("woff"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W35_Thin.ttf") format("truetype"); font-style: normal; font-weight: 300; }
+
+@font-face { font-family: 'Helvetica Neue'; src: url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W35_Thin_Italic.woff2") format("woff2"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W35_Thin_Italic.woff") format("woff"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W35_Thin_Italic.ttf") format("truetype"); font-style: italic; font-weight: 300; }
+
+@font-face { font-family: 'Helvetica Neue'; src: url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W45_Light.woff2") format("woff2"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W45_Light.woff") format("woff"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W45_Light.ttf") format("truetype"); font-style: normal; font-weight: 400; }
+
+@font-face { font-family: 'Helvetica Neue'; src: url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W45_Light_Italic.woff2") format("woff2"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W45_Light_Italic.woff") format("woff"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W45_Light_Italic.ttf") format("truetype"); font-style: italic; font-weight: 400; }
+
+@font-face { font-family: 'Helvetica Neue'; src: url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W55_Normal.woff2") format("woff2"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W55_Normal.woff") format("woff"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W55_Normal.ttf") format("truetype"); font-style: normal; font-weight: 500; }
+
+@font-face { font-family: 'Helvetica Neue'; src: url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W55_Normal_Italic.woff2") format("woff2"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W55_Normal_Italic.woff") format("woff"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W55_Normal_Italic.ttf") format("truetype"); font-style: italic; font-weight: 500; }
+
+@font-face { font-family: 'Helvetica Neue'; src: url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W65_Medium.woff2") format("woff2"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W65_Medium.woff") format("woff"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W65_Medium.ttf") format("truetype"); font-style: normal; font-weight: 600; }
+
+@font-face { font-family: 'Helvetica Neue'; src: url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W65_Medium_Italic.woff2") format("woff2"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W65_Medium_Italic.woff") format("woff"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W65_Medium_Italic.ttf") format("truetype"); font-style: italic; font-weight: 600; }
+
+@font-face { font-family: 'Helvetica Neue'; src: url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W75_Bold.woff2") format("woff2"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W75_Bold.woff") format("woff"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W75_Bold.ttf") format("truetype"); font-style: normal; font-weight: 700; }
+
+@font-face { font-family: 'Helvetica Neue'; src: url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W75_Bold_Italic.woff2") format("woff2"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W75_Bold_Italic.woff") format("woff"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W75_Bold_Italic.ttf") format("truetype"); font-style: italic; font-weight: 700; }
+
+@font-face { font-family: 'Helvetica Neue'; src: url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W85_Heavy.woff2") format("woff2"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W85_Heavy.woff") format("woff"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W85_Heavy.ttf") format("truetype"); font-style: normal; font-weight: 800; }
+
+@font-face { font-family: 'Helvetica Neue'; src: url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W85_Heavy_Italic.woff2") format("woff2"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W85_Heavy_Italic.woff") format("woff"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W85_Heavy_Italic.ttf") format("truetype"); font-style: italic; font-weight: 800; }
+
+@font-face { font-family: 'Helvetica Neue'; src: url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W95_Black.woff2") format("woff2"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W95_Black.woff") format("woff"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W95_Black.ttf") format("truetype"); font-style: normal; font-weight: 900; }
+
+@font-face { font-family: 'Helvetica Neue'; src: url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W95_Black_Italic.woff2") format("woff2"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W95_Black_Italic.woff") format("woff"), url("https://assets.turing.io/fonts/Helvetica_Neue_LT_Std-W95_Black_Italic.ttf") format("truetype"); font-style: italic; font-weight: 900; }
+
+@font-face { font-family: "Roboto Slab"; src: url("/assets/fonts/RobotoSlab-Light.ttf"); font-style: normal; font-weight: 300; }
+
+@font-face { font-family: "Roboto Slab"; src: url("/assets/fonts/RobotoSlab-Regular.ttf"); font-style: normal; font-weight: 400; }
+
+@font-face { font-family: "Roboto Mono"; src: url("/assets/fonts/RobotoMono-Light.ttf"); font-style: normal; font-weight: 300; }
+
+@font-face { font-family: "Roboto Mono"; src: url("/assets/fonts/RobotoMono-Normal.ttf"); font-style: normal; font-weight: 400; }
+
+@font-face { font-family: "Roboto Mono"; src: url("/assets/fonts/RobotoMono-Medium.ttf"); font-style: normal; font-weight: 700; }
+
+:root { /** @title --s-space-0 @category tokens @token_type spacing @value 0rem @description description */ --s-space-0: 0rem; /** @title --s-space-2 @category tokens @token_type spacing @value 0.125rem @description description */ --s-space-2: 0.125rem; /** @title --s-space-4 @category tokens @token_type spacing @value 0.25rem @description description */ --s-space-4: 0.25rem; /** @title --s-space-8 @category tokens @token_type spacing @value 0.5rem @description description */ --s-space-8: 0.5rem; /** @title --s-space-12 @category tokens @token_type spacing @value 0.75rem @description description */ --s-space-12: 0.75rem; /** @title --s-space-16 @category tokens @token_type spacing @value 1rem @description description */ --s-space-16: 1rem; /** @title --s-space-20 @category tokens @token_type spacing @value 1.25rem @description description */ --s-space-20: 1.25rem; /** @title --s-space-24 @category tokens @token_type spacing @value 1.5rem @description description */ --s-space-24: 1.5rem; /** @title --s-space-28 @category tokens @token_type spacing @value 1.75rem @description description */ --s-space-28: 1.75rem; /** @title --s-space-32 @category tokens @token_type spacing @value 2rem @description description */ --s-space-32: 2rem; /** @title --s-space-40 @category tokens @token_type spacing @value 2.5rem @description description */ --s-space-40: 2.5rem; /** @title --s-space-48 @category tokens @token_type spacing @value 3rem @description description */ --s-space-48: 3rem; /** @title --s-space-56 @category tokens @token_type spacing @value 3.5rem @description description */ --s-space-56: 3.5rem; /** @title --s-space-64 @category tokens @token_type spacing @value 4rem @description description */ --s-space-64: 4rem; }
+
+:root { /** @title --s-shadow-s @category tokens @token_type shadows @value 0 1px 3px hsla(0, 0%, 0.2) @description description */ --s-shadow-s: 0 1px 3px hsla(0, 0%, 0.2); /** @title --s-shadow-m @category tokens @token_type shadows @value 0 4px 6px hsla(0, 0%, 0.2) @description description */ --s-shadow-m: 0 4px 6px hsla(0, 0%, 0.2); /** @title --s-shadow-l @category tokens @token_type shadows @value 0 15px 35px hsla(0, 0%, 0.2) @description description */ --s-shadow-l: 0 15px 35px hsla(0, 0%, 0.2); }
+
+:root { /** @title --s-color-cyan-400 @category colors @value #12f1fc @description description */ --s-color-cyan-400: #12f1fc; /** @title --s-color-cyan-500 @category colors @value #05c2d1 @description description */ --s-color-cyan-500: #05c2d1; /** @title --s-color-cyan-600 @category colors @value #0492a5 @description description */ --s-color-cyan-600: #0492a5; /** @title --s-color-cyan-700 @category colors @value #036575 @description description */ --s-color-cyan-700: #036575; /** @title --s-color-yellow-500 @category colors @value #f9ae06 @description description */ --s-color-yellow-500: #f9ae06; /** @title --s-color-yellow-600 @category colors @value #e0990a @description description */ --s-color-yellow-600: #e0990a; /** @title --s-color-yellow-700 @category colors @value #c67b02 @description description */ --s-color-yellow-700: #c67b02; /** @title --s-color-red-500 @category colors @value #ef3852 @description description */ --s-color-red-500: #ef3852; /** @title --s-color-red-600 @category colors @value #cc193b @description description */ --s-color-red-600: #cc193b; /** @title --s-color-red-700 @category colors @value #9b0428 @description description */ --s-color-red-700: #9b0428; /** @title --s-color-white @category colors @value #ffffff @description description */ --s-color-white: #ffffff; /** @title --s-color-gray-100 @category colors @value #f8f8f8 @description description */ --s-color-gray-100: #f8f8f8; /** @title --s-color-gray-200 @category colors @value #eeeff0 @description description */ --s-color-gray-200: #eeeff0; /** @title --s-color-gray-300 @category colors @value #e0e1e2 @description description */ --s-color-gray-300: #e0e1e2; /** @title --s-color-gray-400 @category colors @value #bcbec0 @description description */ --s-color-gray-400: #bcbec0; /** @title --s-color-gray-500 @category colors @value #939598 @description description */ --s-color-gray-500: #939598; /** @title --s-color-gray-600 @category colors @value #6d6e71 @description description */ --s-color-gray-600: #6d6e71; /** @title --s-color-gray-700 @category colors @value #4d4d4f @description description */ --s-color-gray-700: #4d4d4f; /** @title --s-color-gray-800 @category colors @value #2b2b2b @description description */ --s-color-gray-800: #2b2b2b; /** @title --s-color-black @category colors @value #000000 @description description */ --s-color-black: #000000; }
+
+/** @title Heading 1 @category typography @value .s-h1 @order 1 */
+.s-h1 { font-family: var(--s-font-family-default); font-size: var(--s-font-size-xxl); font-weight: var(--s-font-weight-bold); }
+
+/** @title Heading 2 @category typography @value .s-h2 @order 2 */
+.s-h2 { font-family: var(--s-font-family-default); font-size: var(--s-font-size-xl); font-weight: var(--s-font-weight-bold); }
+
+/** @title Heading 3 @category typography @value .s-h3 @order 3 */
+.s-h3 { font-family: var(--s-font-family-default); font-size: var(--s-font-size-lg); font-weight: var(--s-font-weight-heavy); }
+
+/** @title Heading 4 @category typography @value .s-h4 @order 4 */
+.s-h4 { font-family: var(--s-font-family-default); font-size: var(--s-font-size-md); font-weight: var(--s-font-weight-heavy); }
+
+/** @title Heading 5 @category typography @value .s-h5 @order 5 */
+.s-h5 { font-family: var(--s-font-family-default); font-size: var(--s-font-size-md); font-weight: var(--s-font-weight-bold); }
+
+/** @title Heading 6 @category typography @value .s-h6 @order 6 */
+.s-h6 { font-family: var(--s-font-family-default); font-size: var(--s-font-size-sm); font-weight: var(--s-font-weight-heavy); }
+
+/** @title Body Text @category typography @value .s-text-body @order 7 */
+.s-text-body { font-family: var(--s-font-family-default); font-size: var(--s-font-size-md); font-weight: var(--s-font-weight-normal); }
+
+/** @title Small Body Text @category typography @value .s-text-body-sm @order 8 */
+.s-text-body-sm { font-family: var(--s-font-family-default); font-size: var(--s-font-size-sm); font-weight: var(--s-font-weight-normal); }
+
+/** @title Extra Small Body Text @category typography @value .s-text-body-xs @order 9 */
+.s-text-body-xs { font-family: var(--s-font-family-default); font-size: var(--s-font-size-xs); font-weight: var(--s-font-weight-normal); }
+
+/** @title s-border @category utils @util_type border @border_group sides @example <span class="s-border"></span> */
+.s-border { border: var(--s-space-2) solid var(--s-color-cyan-500); }
+
+/** @title s-border-top @category utils @util_type border @border_group sides @example <span class="s-border-top"></span> */
+.s-border-top { border-top: var(--s-space-2) solid var(--s-color-cyan-500); }
+
+/** @title s-border-right @category utils @util_type border @border_group sides @example <span class="s-border-right"></span> */
+.s-border-right { border-right: var(--s-space-2) solid var(--s-color-cyan-500); }
+
+/** @title s-border-bottom @category utils @util_type border @border_group sides @example <span class="s-border-bottom"></span> */
+.s-border-bottom { border-bottom: var(--s-space-2) solid var(--s-color-cyan-500); }
+
+/** @title s-border-left @category utils @util_type border @border_group sides @example <span class="s-border-left"></span> */
+.s-border-left { border-left: var(--s-space-2) solid var(--s-color-cyan-500); }
+
+/** @title s-border-width-0 @category utils @util_type border @border_group width @example <span class="s-border s-border-width-0"></span> */
+.s-border-width-0 { border-width: var(--s-space-0); }
+
+/** @title s-border-width-1 @category utils @util_type border @border_group width @example <span class="s-border s-border-width-1"></span> */
+.s-border-width-1 { border-width: var(--s-space-2); }
+
+/** @title s-border-width-2 @category utils @util_type border @border_group width @example <span class="s-border s-border-width-2"></span> */
+.s-border-width-2 { border-width: var(--s-space-4); }
+
+/** @title s-border-width-3 @category utils @util_type border @border_group width @example <span class="s-border s-border-width-3"></span> */
+.s-border-width-3 { border-width: var(--s-space-8); }
+
+/** @title s-border-width-4 @category utils @util_type border @border_group width @example <span class="s-border s-border-width-4"></span> */
+.s-border-width-4 { border-width: var(--s-space-12); }
+
+/** @title s-border-radius-0 @category utils @util_type border @border_group radius @example <span class="s-border-radius-0"></span> */
+.s-border-radius-0 { border-radius: var(--s-space-0); }
+
+/** @title s-border-radius-1 @category utils @util_type border @border_group radius @example <span class="s-border-radius-1"></span> */
+.s-border-radius-1 { border-radius: var(--s-space-4); }
+
+/** @title s-border-radius-2 @category utils @util_type border @border_group radius @example <span class="s-border-radius-2"></span> */
+.s-border-radius-2 { border-radius: var(--s-space-16); }
+
+/** @title s-border-radius-circle @category utils @util_type border @border_group radius @example <span class="s-border-radius-circle"></span> */
+.s-border-radius-circle { border-radius: 50%; }
+
+/** @title s-border-radius-pill @category utils @util_type border @border_group radius @example <span class="s-border-radius-pill"></span> */
+.s-border-radius-pill { border-radius: 50rem; }
+
+/** @title Primary Button @category elements @status draft @description Our basic button Some more description @example <button class="primary-button"> Click me </button> */
+.primary-button { border: none; border-radius: 50px; font-size: 14px; letter-spacing: .5px; line-height: 17px; text-transform: uppercase; padding: 18px 40px 12px; display: inline-block; color: var(--s-color-cyan-700); background-color: var(--s-color-cyan-400); }
+
+/** @title Primary Inverse Button @category elements @status draft @description Our basic button Some more description @example <button class="s-button-primary-inverse"> Click me </button> */
+.s-button-primary-inverse { border: none; border-radius: 50px; font-size: 14px; letter-spacing: .5px; line-height: 17px; text-transform: uppercase; padding: 18px 40px 12px; display: inline-block; color: var(--s-color-cyan-400); background-color: var(--s-color-cyan-700); }
+
+/** @title Secondary Button @category elements @status draft @description Our basic button Some more description @example <button class="secondary-button"> Click me </button> */
+.secondary-button { border: none; border-radius: 50px; font-size: 14px; letter-spacing: .5px; line-height: 17px; text-transform: uppercase; padding: 18px 40px 12px; display: inline-block; color: var(--s-color-gray-700); background-color: var(--s-color-gray-100); border: 2px solid var(--s-color-gray-700); }
+
+/** @title Paragraph @category elements @element_type text @status draft @value s-p @description A paragraph element with built-in size, color, and font-family. To be used with a white background. @example <p class="s-p">The default paragraph text is 16px and is intended for text on a white background.</p> */
+.s-p { color: var(--s-color-gray-600); font-size: var(--s-font-size-md); }
+
+:root { --nav-height: 4rem; }
+
+/** @title Primary Nav @category components @status early draft @description Navigation component w/ primary and secondary variants. @example <nav class="nav nav-primary"> <ul> <li>Nav element 1</li> <li>Nav element 2</li> </ul> </nav> */
+.nav { font-weight: var(--s-font-weight-bold); height: var(--nav-height); position: sticky; width: 100%; z-index: 99; margin-bottom: 0.5rem; }
+
+.nav ul { list-style-type: none; display: flex; flex-direction: row; justify-content: space-between; align-items: flex-end; }
+
+.nav ul li { text-align: center; padding: 1rem; }
+
+.nav ul li a { color: var(--color-primary); text-transform: uppercase; }
+
+.nav.nav-primary { background: var(--color-white); top: 0; }
+
+.nav.nav-secondary { background: var(--color-primary-dark); color: var(--color-white); position: sticky; top: var(--nav-height); }
+
+/*# sourceMappingURL=main.css.map */

--- a/docs/_components/Primary Nav.md
+++ b/docs/_components/Primary Nav.md
@@ -3,7 +3,7 @@ title: Primary Nav
 category: components
 status: early draft
 description: Navigation component w/ primary and secondary variants.
-order: 28
+order: 29
 ---
 <nav class="nav nav-primary">
   <ul>

--- a/docs/_elements/Paragraph.md
+++ b/docs/_elements/Paragraph.md
@@ -1,0 +1,11 @@
+---
+title: Paragraph
+category: elements
+element_type: text
+status: draft
+value: s-p
+description: A paragraph element with built-in size, color, and font-family. To be
+  used with a white background.
+order: 28
+---
+<p class="s-p">The default paragraph text is 16px and is intended for text on a white background.</p>


### PR DESCRIPTION
This PR adds a paragraph element to complete VERSION 1 (fake)

The steps I took:
- Do necessary work to add elements, etc. for X version
- Copy and paste code that exists locally from `_site/css/main.css` into a newly created folder named after X version, commit

This worked last time, I am anticipating that once this is merged we can expect:
- main is updated with these changes (normal)
- fake-Savile users can now go to `https://ameseee.github.io/s-versioning-spike/css/versions/v-alpha.css`, `https://ameseee.github.io/s-versioning-spike/css/versions/v-beta.css`,  OR `https://ameseee.github.io/s-versioning-spike/css/versions/v-1.css` (the difference is small, scroll to very bottom and you'll see the addition of buttons and paragraph as you progress through the 3 links.
